### PR TITLE
Use 2d array implementation for the chessboard

### DIFF
--- a/src/chess.rs
+++ b/src/chess.rs
@@ -54,7 +54,7 @@ pub enum MetaData {
 pub const ROW_SIZE: usize = 8;
 pub const COL_SIZE: usize = 8;
 type Board = [[BoardSquare; COL_SIZE]; ROW_SIZE];
-type Coordinates = (usize, usize);
+type Coordinate = (usize, usize);
 
 const EMPTY_PIECE: BoardSquare = BoardSquare {
     piece_type: Square::Empty,
@@ -66,7 +66,7 @@ pub struct ChessBoard {
     board: Board,
     white_is_side_to_move: bool,
     castling_ability: [bool; 4], // WKingside, WQueenside, BKingside, BQueenside
-    en_passant_target_square: Option<Coordinates>,
+    en_passant_target_square: Option<Coordinate>,
     halfmove_clock: u64,
     fullmove_counter: u64,
     is_checked: bool,
@@ -81,8 +81,8 @@ pub struct BoardSquare {
 
 #[derive(PartialEq)]
 pub(crate) struct Move {
-    pub start_pos: Coordinates,
-    pub end_pos: Coordinates,
+    pub start_pos: Coordinate,
+    pub end_pos: Coordinate,
     pub meta_data: MetaData,
 }
 

--- a/src/chess.rs
+++ b/src/chess.rs
@@ -19,13 +19,18 @@ use fen::FEN_START_POSITION;
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum Square {
     Empty,
-    White(Pieces),
-    Black(Pieces),
+    Piece(Piece),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Piece {
+    White(PieceType),
+    Black(PieceType),
 }
 
 /* Defines different piece types and color */
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub enum Pieces {
+pub enum PieceType {
     Pawn,
     Rook,
     Bishop,
@@ -43,12 +48,13 @@ pub enum MetaData {
     Capture,
     EnPassant,
     Castling,
-    Promotion(Pieces),
+    Promotion(Piece),
 }
 
 pub const ROW_SIZE: usize = 8;
 pub const COL_SIZE: usize = 8;
 type Board = [[BoardSquare; COL_SIZE]; ROW_SIZE];
+type Coordinates = (usize, usize);
 
 const EMPTY_PIECE: BoardSquare = BoardSquare {
     piece_type: Square::Empty,
@@ -60,7 +66,7 @@ pub struct ChessBoard {
     board: Board,
     white_is_side_to_move: bool,
     castling_ability: [bool; 4], // WKingside, WQueenside, BKingside, BQueenside
-    en_passant_target_square: Option<(usize, usize)>,
+    en_passant_target_square: Option<Coordinates>,
     halfmove_clock: u64,
     fullmove_counter: u64,
     is_checked: bool,
@@ -75,19 +81,9 @@ pub struct BoardSquare {
 
 #[derive(PartialEq)]
 pub(crate) struct Move {
-    pub start_pos: (usize, usize),
-    pub end_pos: (usize, usize),
+    pub start_pos: Coordinates,
+    pub end_pos: Coordinates,
     pub meta_data: MetaData,
-}
-
-impl fmt::Display for Move {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            f,
-            "start_pos: ({}, {}), end_pos: ({}, {})\n",
-            self.start_pos.0, self.start_pos.1, self.end_pos.0, self.end_pos.1
-        )
-    }
 }
 
 // Implements chess functionality

--- a/src/chess.rs
+++ b/src/chess.rs
@@ -1,11 +1,10 @@
 /* Sub-module for FEN helper functions */
 
-use core::fmt;
-
 use crate::chess::fen::{
     is_fen_valid, parse_fen_castling_ability, parse_fen_epawn, parse_fen_full_move_counter,
     parse_fen_half_move_clock, parse_fen_piece_placement, parse_fen_side_to_move, split_at_space,
 };
+
 pub mod fen;
 
 /* Module that allows printing a chessboard to the CLI */
@@ -20,7 +19,7 @@ pub const ROW_SIZE: usize = 8;
 pub const COL_SIZE: usize = 8;
 
 type Board = [[Square; COL_SIZE]; ROW_SIZE];
-type Coordinate = (usize, usize);
+type Position = (usize, usize);
 type Square = Option<Piece>;
 
 /** Defines different chess piece types. */
@@ -72,7 +71,7 @@ pub struct ChessBoard {
     board: Board,
     white_is_side_to_move: bool,
     castling_ability: [bool; 4], // WKingside, WQueenside, BKingside, BQueenside
-    en_passant_target_square: Option<Coordinate>,
+    en_passant_target_square: Option<Position>,
     half_move_clock: u64,
     full_move_counter: u64,
     is_checked: bool,
@@ -80,10 +79,10 @@ pub struct ChessBoard {
     is_stalemate: bool,
 }
 
-#[derive(PartialEq)]
+#[derive(PartialEq, Copy, Clone)]
 pub(crate) struct Move {
-    pub start_pos: Coordinate,
-    pub end_pos: Coordinate,
+    pub start_pos: Position,
+    pub end_pos: Position,
     pub meta_data: MetaData,
 }
 

--- a/src/chess/chess_display.rs
+++ b/src/chess/chess_display.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 use crate::chess::PieceType::{Bishop, King, Knight, Pawn, Queen, Rook};
-use crate::chess::{Board, ChessBoard, Move, Piece, Square};
+use crate::chess::{Board, ChessBoard, Color, Move, Square};
 
 const T_LINE: &str = "┌—————┬—————┬—————┬—————┬—————┬—————┬—————┬—————┐\n";
 const H_LINE: &str = "|—————|—————|—————|—————|—————|—————|—————|—————|\n";
@@ -58,7 +58,7 @@ fn parse_chessboard_to_string(board: &Board) -> Vec<String> {
         let mut pieces: Vec<char> = Vec::new();
 
         for file in 0..=7 {
-            pieces.push(piece_type_to_char(board[rank][file].piece_type));
+            pieces.push(piece_type_to_char(board[rank][file]));
         }
 
         let rank_string: String = format!(
@@ -72,26 +72,27 @@ fn parse_chessboard_to_string(board: &Board) -> Vec<String> {
     printable_board
 }
 
-fn piece_type_to_char(square_type: Square) -> char {
-    match square_type {
-        Square::Empty => ' ',
+fn piece_type_to_char(square: Square) -> char {
+    match square {
+        None => ' ',
 
-        Square::Piece(Piece::White(Pawn)) => 'P',
-        Square::Piece(Piece::Black(Pawn)) => 'p',
-
-        Square::Piece(Piece::White(Bishop)) => 'B',
-        Square::Piece(Piece::Black(Bishop)) => 'b',
-
-        Square::Piece(Piece::White(Knight)) => 'N',
-        Square::Piece(Piece::Black(Knight)) => 'n',
-
-        Square::Piece(Piece::White(Rook)) => 'R',
-        Square::Piece(Piece::Black(Rook)) => 'r',
-
-        Square::Piece(Piece::White(Queen)) => 'Q',
-        Square::Piece(Piece::Black(Queen)) => 'q',
-
-        Square::Piece(Piece::White(King)) => 'K',
-        Square::Piece(Piece::Black(King)) => 'k',
+        Some(piece) => match piece.color {
+            Color::White => match piece.piece_type {
+                King => 'K',
+                Queen => 'Q',
+                Rook => 'R',
+                Bishop => 'B',
+                Knight => 'N',
+                Pawn => 'P',
+            },
+            Color::Black => match piece.piece_type {
+                King => 'k',
+                Queen => 'q',
+                Rook => 'r',
+                Bishop => 'b',
+                Knight => 'n',
+                Pawn => 'p',
+            },
+        },
     }
 }

--- a/src/chess/chess_display.rs
+++ b/src/chess/chess_display.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::chess::{BoardPiece, ChessBoard, Pieces, ARR_SIZE};
+use crate::chess::{BoardSquare, ChessBoard, Pieces, ARR_SIZE};
 
 const T_LINE: &str = "┌—————┬—————┬—————┬—————┬—————┬—————┬—————┬—————┐\n";
 const H_LINE: &str = "|—————|—————|—————|—————|—————|—————|—————|—————|\n";
@@ -40,7 +40,7 @@ impl fmt::Display for ChessBoard {
     }
 }
 
-fn parse_chessboard_to_string(board: &[BoardPiece; ARR_SIZE]) -> Vec<String> {
+fn parse_chessboard_to_string(board: &[BoardSquare; ARR_SIZE]) -> Vec<String> {
     let mut printable_board = Vec::new();
 
     for rank in 1..=8 {

--- a/src/chess/chess_display.rs
+++ b/src/chess/chess_display.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 
-use crate::chess::{BoardSquare, ChessBoard, Pieces, ARR_SIZE};
+use crate::chess::PieceType::{Bishop, King, Knight, Pawn, Queen, Rook};
+use crate::chess::{Board, ChessBoard, Move, Piece, Square};
 
 const T_LINE: &str = "┌—————┬—————┬—————┬—————┬—————┬—————┬—————┬—————┐\n";
 const H_LINE: &str = "|—————|—————|—————|—————|—————|—————|—————|—————|\n";
@@ -40,15 +41,24 @@ impl fmt::Display for ChessBoard {
     }
 }
 
-fn parse_chessboard_to_string(board: &[BoardSquare; ARR_SIZE]) -> Vec<String> {
+impl fmt::Display for Move {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "start_pos: ({}, {}), end_pos: ({}, {})\n",
+            self.start_pos.0, self.start_pos.1, self.end_pos.0, self.end_pos.1
+        )
+    }
+}
+
+fn parse_chessboard_to_string(board: &Board) -> Vec<String> {
     let mut printable_board = Vec::new();
 
-    for rank in 1..=8 {
-        let start = (rank - 1) * 8;
+    for rank in 0..=7 {
         let mut pieces: Vec<char> = Vec::new();
 
-        for i in 0..=7 {
-            pieces.push(piece_type_to_char(board[start + i].piece_type));
+        for file in 0..=7 {
+            pieces.push(piece_type_to_char(board[rank][file].piece_type));
         }
 
         let rank_string: String = format!(
@@ -62,26 +72,26 @@ fn parse_chessboard_to_string(board: &[BoardSquare; ARR_SIZE]) -> Vec<String> {
     printable_board
 }
 
-fn piece_type_to_char(square_type: Pieces) -> char {
+fn piece_type_to_char(square_type: Square) -> char {
     match square_type {
-        Pieces::Empty => ' ',
+        Square::Empty => ' ',
 
-        Pieces::WPawn => 'P',
-        Pieces::BPawn => 'p',
+        Square::Piece(Piece::White(Pawn)) => 'P',
+        Square::Piece(Piece::Black(Pawn)) => 'p',
 
-        Pieces::WBishop => 'B',
-        Pieces::BBishop => 'b',
+        Square::Piece(Piece::White(Bishop)) => 'B',
+        Square::Piece(Piece::Black(Bishop)) => 'b',
 
-        Pieces::WKnight => 'N',
-        Pieces::BKnight => 'n',
+        Square::Piece(Piece::White(Knight)) => 'N',
+        Square::Piece(Piece::Black(Knight)) => 'n',
 
-        Pieces::WRook => 'R',
-        Pieces::BRook => 'r',
+        Square::Piece(Piece::White(Rook)) => 'R',
+        Square::Piece(Piece::Black(Rook)) => 'r',
 
-        Pieces::WQueen => 'Q',
-        Pieces::BQueen => 'q',
+        Square::Piece(Piece::White(Queen)) => 'Q',
+        Square::Piece(Piece::Black(Queen)) => 'q',
 
-        Pieces::WKing => 'K',
-        Pieces::BKing => 'k',
+        Square::Piece(Piece::White(King)) => 'K',
+        Square::Piece(Piece::Black(King)) => 'k',
     }
 }

--- a/src/chess/chess_moves.rs
+++ b/src/chess/chess_moves.rs
@@ -6,7 +6,7 @@ pub mod meta_data;
 mod piece_logic;
 
 use crate::chess::chess_errors::IllegalMove;
-use crate::chess::{BoardPiece, ChessBoard, Move, Pieces, SquarePosition, ARR_SIZE};
+use crate::chess::{BoardSquare, ChessBoard, Move, Pieces, SquarePosition, ARR_SIZE};
 
 impl ChessBoard {
     pub fn make_move(&mut self, move_to_make: Move) -> Result<Move, IllegalMove> {
@@ -61,7 +61,7 @@ pub struct MoveDirection {
 impl MoveDirection {
     pub fn piece_can_travel(
         &self,
-        board: &[BoardPiece; ARR_SIZE],
+        board: &[BoardSquare; ARR_SIZE],
         friendly_pieces: &[Pieces; 6],
         board_position: &usize,
     ) -> bool {

--- a/src/chess/chess_moves.rs
+++ b/src/chess/chess_moves.rs
@@ -6,7 +6,7 @@ pub mod meta_data;
 mod piece_logic;
 
 use crate::chess::chess_errors::IllegalMove;
-use crate::chess::{BoardSquare, ChessBoard, Move, Pieces, SquarePosition, ARR_SIZE};
+use crate::chess::{Board, ChessBoard, Coordinates, Move, Piece, Square};
 
 impl ChessBoard {
     pub fn make_move(&mut self, move_to_make: Move) -> Result<Move, IllegalMove> {
@@ -32,26 +32,6 @@ impl ChessBoard {
     }
 }
 
-impl SquarePosition {
-    pub fn pos_to_arr_index(&self) -> usize {
-        if self.rank == 0 || self.file == 0 {
-            panic!(
-                "ERROR: square position {}, {}. Should be above 0",
-                self.rank, self.file
-            );
-        }
-
-        (self.rank - 1) * 8 + self.file - 1
-    }
-
-    pub fn new(arr_pos: usize) -> SquarePosition {
-        let rank = (arr_pos / 8) + 1;
-        let file = (arr_pos % 8) + 1;
-
-        SquarePosition { rank, file }
-    }
-}
-
 #[derive(Clone, Copy)]
 pub struct MoveDirection {
     dx: i8,
@@ -61,58 +41,46 @@ pub struct MoveDirection {
 impl MoveDirection {
     pub fn piece_can_travel(
         &self,
-        board: &[BoardSquare; ARR_SIZE],
-        friendly_pieces: &[Pieces; 6],
-        board_position: &usize,
+        board: &Board,
+        friendly_pieces: &Piece,
+        board_position: &Coordinates,
     ) -> bool {
-        let mut piece_square = SquarePosition::new(*board_position);
-
-        let x_pos: i8 = (piece_square.file as i8) + self.dx;
-        let y_pos: i8 = (piece_square.rank as i8) + self.dy;
-
-        if x_pos < 1 || y_pos < 1 || x_pos > 8 || y_pos > 8 {
+        if self.dx < 0 && self.dx.abs() as usize > board_position.0
+            || self.dy < 0 && self.dy.abs() as usize > board_position.1
+        {
             return false;
-        } else {
-            piece_square.file = x_pos as usize;
-            piece_square.rank = y_pos as usize;
+        } else if self.dx as usize + board_position.0 > 7 || self.dy as usize + board_position.1 > 7
+        {
+            return false;
         }
 
-        let target_piece = board[piece_square.pos_to_arr_index()].piece_type;
+        let target_piece = board[board_position.1][board_position.0].piece_type;
 
-        for friend in friendly_pieces {
-            if *friend == target_piece {
-                return false;
-            }
+        match target_piece {
+            Square::Empty => true,
+
+            Square::Piece(piece) => match piece {
+                Piece::White(_) => match friendly_pieces {
+                    Piece::White(_) => false,
+                    Piece::Black(_) => true,
+                },
+
+                Piece::Black(_) => match friendly_pieces {
+                    Piece::White(_) => true,
+                    Piece::Black(_) => false,
+                },
+            },
         }
-        true
     }
 
     /**
       given a position this function returns a new position after traveling the direction given by
       self.
     */
-    pub fn walk_from_position(&self, position: usize) -> usize {
-        let new_position: usize;
-        let mut move_is_valid = true;
-
-        let delta_position: i8 = self.dx + (self.dy * 8);
-
-        let square_position = SquarePosition::new(position);
-
-        if (square_position.file as i8 + self.dx) < 1 || (square_position.rank as i8 + self.dy) < 1
-        {
-            move_is_valid = false;
-        }
-
-        if !move_is_valid {
-            panic!(
-                "Error walking from position: Check that a move is within bounds before \
-            calling this function!"
-            )
-        } else {
-            new_position = (position as i8 + delta_position) as usize;
-        }
-
-        new_position
+    pub fn walk_from_position(&self, position: Coordinates) -> Coordinates {
+        (
+            (position.0 as i8 + self.dx) as usize,
+            (position.1 as i8 + self.dy) as usize,
+        )
     }
 }

--- a/src/chess/chess_moves.rs
+++ b/src/chess/chess_moves.rs
@@ -47,15 +47,17 @@ impl MoveDirection {
     ) -> bool {
         let casted_x: i8 = board_position.0 as i8;
         let casted_y: i8 = board_position.1 as i8;
-        if self.dx + casted_x > 7
-            || self.dx + casted_x < 0
-            || self.dy + casted_y > 7
-            || self.dy + casted_y < 0
-        {
+
+        let new_i8_x: i8 = self.dx + casted_x;
+        let new_i8_y: i8 = self.dy + casted_y;
+
+        if new_i8_x > 7 || new_i8_x < 0 || new_i8_y > 7 || new_i8_y < 0 {
             return false;
         }
 
-        let target_piece = board[board_position.1][board_position.0];
+        let new_x: usize = new_i8_x as usize;
+        let new_y: usize = new_i8_y as usize;
+        let target_piece = board[new_y][new_x];
 
         match target_piece {
             None => true,

--- a/src/chess/chess_moves.rs
+++ b/src/chess/chess_moves.rs
@@ -6,7 +6,7 @@ pub mod meta_data;
 mod piece_logic;
 
 use crate::chess::chess_errors::IllegalMove;
-use crate::chess::{Board, ChessBoard, Color, Coordinate, Move, Piece, Square};
+use crate::chess::{Board, ChessBoard, Color, Move, Position};
 
 impl ChessBoard {
     pub fn make_move(&mut self, move_to_make: Move) -> Result<Move, IllegalMove> {
@@ -43,13 +43,14 @@ impl MoveDirection {
         &self,
         board: &Board,
         friendly_piece_color: &Color,
-        board_position: &Coordinate,
+        board_position: &Position,
     ) -> bool {
-        if self.dx < 0 && self.dx.unsigned_abs() as usize > board_position.0
-            || self.dy < 0 && self.dy.unsigned_abs() as usize > board_position.1
-        {
-            return false;
-        } else if self.dx as usize + board_position.0 > 7 || self.dy as usize + board_position.1 > 7
+        let casted_x: i8 = board_position.0 as i8;
+        let casted_y: i8 = board_position.1 as i8;
+        if self.dx + casted_x > 7
+            || self.dx + casted_x < 0
+            || self.dy + casted_y > 7
+            || self.dy + casted_y < 0
         {
             return false;
         }
@@ -73,7 +74,7 @@ impl MoveDirection {
       given a position this function returns a new position after traveling the direction given by
       self.
     */
-    pub fn walk_from_position(&self, position: Coordinate) -> Coordinate {
+    pub fn walk_from_position(&self, position: Position) -> Position {
         (
             (position.0 as i8 + self.dx) as usize,
             (position.1 as i8 + self.dy) as usize,

--- a/src/chess/chess_moves.rs
+++ b/src/chess/chess_moves.rs
@@ -6,7 +6,7 @@ pub mod meta_data;
 mod piece_logic;
 
 use crate::chess::chess_errors::IllegalMove;
-use crate::chess::{Board, ChessBoard, Coordinates, Move, Piece, Square};
+use crate::chess::{Board, ChessBoard, Coordinate, Move, Piece, Square};
 
 impl ChessBoard {
     pub fn make_move(&mut self, move_to_make: Move) -> Result<Move, IllegalMove> {
@@ -43,7 +43,7 @@ impl MoveDirection {
         &self,
         board: &Board,
         friendly_pieces: &Piece,
-        board_position: &Coordinates,
+        board_position: &Coordinate,
     ) -> bool {
         if self.dx < 0 && self.dx.abs() as usize > board_position.0
             || self.dy < 0 && self.dy.abs() as usize > board_position.1
@@ -77,7 +77,7 @@ impl MoveDirection {
       given a position this function returns a new position after traveling the direction given by
       self.
     */
-    pub fn walk_from_position(&self, position: Coordinates) -> Coordinates {
+    pub fn walk_from_position(&self, position: Coordinate) -> Coordinate {
         (
             (position.0 as i8 + self.dx) as usize,
             (position.1 as i8 + self.dy) as usize,

--- a/src/chess/chess_moves.rs
+++ b/src/chess/chess_moves.rs
@@ -6,7 +6,7 @@ pub mod meta_data;
 mod piece_logic;
 
 use crate::chess::chess_errors::IllegalMove;
-use crate::chess::{Board, ChessBoard, Coordinate, Move, Piece, Square};
+use crate::chess::{Board, ChessBoard, Color, Coordinate, Move, Piece, Square};
 
 impl ChessBoard {
     pub fn make_move(&mut self, move_to_make: Move) -> Result<Move, IllegalMove> {
@@ -42,11 +42,11 @@ impl MoveDirection {
     pub fn piece_can_travel(
         &self,
         board: &Board,
-        friendly_pieces: &Piece,
+        friendly_piece_color: &Color,
         board_position: &Coordinate,
     ) -> bool {
-        if self.dx < 0 && self.dx.abs() as usize > board_position.0
-            || self.dy < 0 && self.dy.abs() as usize > board_position.1
+        if self.dx < 0 && self.dx.unsigned_abs() as usize > board_position.0
+            || self.dy < 0 && self.dy.unsigned_abs() as usize > board_position.1
         {
             return false;
         } else if self.dx as usize + board_position.0 > 7 || self.dy as usize + board_position.1 > 7
@@ -54,22 +54,18 @@ impl MoveDirection {
             return false;
         }
 
-        let target_piece = board[board_position.1][board_position.0].piece_type;
+        let target_piece = board[board_position.1][board_position.0];
 
         match target_piece {
-            Square::Empty => true,
+            None => true,
 
-            Square::Piece(piece) => match piece {
-                Piece::White(_) => match friendly_pieces {
-                    Piece::White(_) => false,
-                    Piece::Black(_) => true,
-                },
-
-                Piece::Black(_) => match friendly_pieces {
-                    Piece::White(_) => true,
-                    Piece::Black(_) => false,
-                },
-            },
+            Some(piece) => {
+                if piece.color == *friendly_piece_color {
+                    false
+                } else {
+                    true
+                }
+            }
         }
     }
 

--- a/src/chess/chess_moves/legal_moves.rs
+++ b/src/chess/chess_moves/legal_moves.rs
@@ -15,7 +15,9 @@ use crate::chess::chess_moves::legal_moves::knight_piece::get_knight_moves;
 use crate::chess::chess_moves::legal_moves::pawn_piece::get_pawn_moves;
 use crate::chess::chess_moves::legal_moves::queen_piece::get_queen_moves;
 use crate::chess::chess_moves::legal_moves::rook_piece::get_rook_moves;
-use crate::chess::{Board, BoardSquare, ChessBoard, MetaData, Move, Pieces, ARR_SIZE, EMPTY_PIECE};
+use crate::chess::{
+    Board, BoardSquare, ChessBoard, MetaData, Move, Pieces, ARR_SIZE, EMPTY_SQUARE,
+};
 
 impl ChessBoard {
     pub fn legal_moves(&self) -> Vec<Move> {
@@ -94,12 +96,12 @@ impl ChessBoard {
         match move_to_make.meta_data {
             MetaData::Move | MetaData::PawnMove | MetaData::Capture | MetaData::PawnDoubleMove => {
                 board[move_to_make.end_pos] = board[move_to_make.start_pos];
-                board[move_to_make.start_pos] = EMPTY_PIECE;
+                board[move_to_make.start_pos] = EMPTY_SQUARE;
             }
 
             MetaData::Promotion(piece_type) => {
                 board[move_to_make.end_pos] = BoardSquare { piece_type };
-                board[move_to_make.start_pos] = EMPTY_PIECE;
+                board[move_to_make.start_pos] = EMPTY_SQUARE;
             }
 
             MetaData::EnPassant => {
@@ -111,8 +113,8 @@ impl ChessBoard {
 
                 board[move_to_make.end_pos] = board[move_to_make.start_pos];
 
-                board[move_to_make.start_pos] = EMPTY_PIECE;
-                board[(move_to_make.end_pos as i8 + delta_position) as usize] = EMPTY_PIECE;
+                board[move_to_make.start_pos] = EMPTY_SQUARE;
+                board[(move_to_make.end_pos as i8 + delta_position) as usize] = EMPTY_SQUARE;
             }
 
             MetaData::Castling => {
@@ -126,8 +128,8 @@ impl ChessBoard {
                 board[move_to_make.end_pos] = board[move_to_make.start_pos];
                 board[rook_end_position] = board[rook_start_position];
 
-                board[move_to_make.start_pos] = EMPTY_PIECE;
-                board[rook_start_position] = EMPTY_PIECE;
+                board[move_to_make.start_pos] = EMPTY_SQUARE;
+                board[rook_start_position] = EMPTY_SQUARE;
             }
         }
     }

--- a/src/chess/chess_moves/legal_moves.rs
+++ b/src/chess/chess_moves/legal_moves.rs
@@ -15,7 +15,6 @@ use crate::chess::chess_moves::legal_moves::queen_piece::get_queen_moves;
 use crate::chess::chess_moves::legal_moves::rook_piece::get_rook_moves;
 use crate::chess::PieceType::{Bishop, King, Knight, Pawn, Queen, Rook};
 use crate::chess::{Board, ChessBoard, Color, MetaData, Move, Piece, PieceType, Position};
-use iced::widget::shader::wgpu::naga::back::msl::sampler::Coord;
 
 impl ChessBoard {
     pub fn legal_moves(&self) -> Vec<Move> {
@@ -61,37 +60,47 @@ impl ChessBoard {
             for (column, square) in squares.iter().enumerate() {
                 match square {
                     None => continue,
-                    Some(piece) => match piece.piece_type {
-                        King => {
-                            let mut moves = get_king_moves(self, &friendly_color, &(column, row));
-                            pseudo_legal_moves.append(&mut moves);
-                        }
+                    Some(piece) => {
+                        if piece.color == friendly_color {
+                            match piece.piece_type {
+                                King => {
+                                    let mut moves =
+                                        get_king_moves(self, &friendly_color, &(column, row));
+                                    pseudo_legal_moves.append(&mut moves);
+                                }
 
-                        Queen => {
-                            let mut moves = get_queen_moves(self, &friendly_color, &(column, row));
-                            pseudo_legal_moves.append(&mut moves);
-                        }
+                                Queen => {
+                                    let mut moves =
+                                        get_queen_moves(self, &friendly_color, &(column, row));
+                                    pseudo_legal_moves.append(&mut moves);
+                                }
 
-                        Rook => {
-                            let mut moves = get_rook_moves(self, &friendly_color, &(column, row));
-                            pseudo_legal_moves.append(&mut moves);
-                        }
+                                Rook => {
+                                    let mut moves =
+                                        get_rook_moves(self, &friendly_color, &(column, row));
+                                    pseudo_legal_moves.append(&mut moves);
+                                }
 
-                        Bishop => {
-                            let mut moves = get_bishop_moves(self, &friendly_color, &(column, row));
-                            pseudo_legal_moves.append(&mut moves);
-                        }
+                                Bishop => {
+                                    let mut moves =
+                                        get_bishop_moves(self, &friendly_color, &(column, row));
+                                    pseudo_legal_moves.append(&mut moves);
+                                }
 
-                        Knight => {
-                            let mut moves = get_knight_moves(self, &friendly_color, &(column, row));
-                            pseudo_legal_moves.append(&mut moves);
-                        }
+                                Knight => {
+                                    let mut moves =
+                                        get_knight_moves(self, &friendly_color, &(column, row));
+                                    pseudo_legal_moves.append(&mut moves);
+                                }
 
-                        Pawn => {
-                            let mut moves = get_pawn_moves(self, &friendly_color, &(column, row));
-                            pseudo_legal_moves.append(&mut moves);
+                                Pawn => {
+                                    let mut moves =
+                                        get_pawn_moves(self, &friendly_color, &(column, row));
+                                    pseudo_legal_moves.append(&mut moves);
+                                }
+                            }
                         }
-                    },
+                    }
                 }
             }
         }

--- a/src/chess/chess_moves/legal_moves.rs
+++ b/src/chess/chess_moves/legal_moves.rs
@@ -7,40 +7,37 @@ mod queen_piece;
 mod rook_piece;
 
 use crate::chess::chess_moves::legal_moves::bishop_piece::get_bishop_moves;
-use crate::chess::chess_moves::legal_moves::generic_piece::{
-    find_first_matching_chess_piece, Color,
-};
+use crate::chess::chess_moves::legal_moves::generic_piece::find_first_matching_chess_piece;
 use crate::chess::chess_moves::legal_moves::king_piece::{get_king_moves, king_is_checked};
 use crate::chess::chess_moves::legal_moves::knight_piece::get_knight_moves;
 use crate::chess::chess_moves::legal_moves::pawn_piece::get_pawn_moves;
 use crate::chess::chess_moves::legal_moves::queen_piece::get_queen_moves;
 use crate::chess::chess_moves::legal_moves::rook_piece::get_rook_moves;
-use crate::chess::{
-    Board, BoardSquare, ChessBoard, MetaData, Move, Pieces, ARR_SIZE, EMPTY_SQUARE,
-};
+use crate::chess::PieceType::{Bishop, King, Knight, Pawn, Queen, Rook};
+use crate::chess::{Board, ChessBoard, Color, MetaData, Move, Piece, PieceType, Position};
+use iced::widget::shader::wgpu::naga::back::msl::sampler::Coord;
 
 impl ChessBoard {
     pub fn legal_moves(&self) -> Vec<Move> {
-        let mut legal_moves: Vec<Move> = Vec::new();
+        let mut legal_moves: Vec<Move> = Vec::with_capacity(50);
+
+        let current_color: Color = if self.white_is_side_to_move {
+            Color::White
+        } else {
+            Color::Black
+        };
 
         let pseudo_legal_moves: Vec<Move> = self.pseudo_legal_moves();
 
-        let king_position = find_first_matching_chess_piece(&self.board, king_piece)
-            .expect("Both kings most exist on all boards!");
+        let king_position = find_first_matching_chess_piece(
+            &self.board,
+            &Piece::new(current_color, PieceType::King),
+        )
+        .expect("Both kings most exist on all boards!");
 
         for piece_move in pseudo_legal_moves {
             let mut board_copy = self.board;
             Self::make_move_on_board(&mut board_copy, &piece_move);
-
-            if board_copy[piece_move.end_pos].piece_type == Pieces::WKing
-                || board_copy[piece_move.end_pos].piece_type == Pieces::BKing
-            {
-                if !king_is_checked(&board_copy, &piece_move.end_pos, &current_color) {
-                    legal_moves.push(piece_move);
-                }
-
-                continue;
-            }
 
             if !king_is_checked(&board_copy, &king_position, &current_color) {
                 legal_moves.push(piece_move);
@@ -54,38 +51,47 @@ impl ChessBoard {
     fn pseudo_legal_moves(&self) -> Vec<Move> {
         let mut pseudo_legal_moves: Vec<Move> = Vec::new();
 
-        for (index, piece) in self.board.iter().enumerate() {
-            match piece.piece_type {
-                Pieces::Empty => continue,
+        let friendly_color = if self.white_is_side_to_move {
+            Color::White
+        } else {
+            Color::Black
+        };
 
-                Pieces::WKing | Pieces::BKing => {
-                    let mut king_moves = get_king_moves(self, &index);
-                    pseudo_legal_moves.append(&mut king_moves);
-                }
+        for (row, squares) in self.board.iter().enumerate() {
+            for (column, square) in squares.iter().enumerate() {
+                match square {
+                    None => continue,
+                    Some(piece) => match piece.piece_type {
+                        King => {
+                            let mut moves = get_king_moves(self, &friendly_color, &(column, row));
+                            pseudo_legal_moves.append(&mut moves);
+                        }
 
-                Pieces::WQueen | Pieces::BQueen => {
-                    let mut queen_moves = get_queen_moves(self, &index);
-                    pseudo_legal_moves.append(&mut queen_moves);
-                }
+                        Queen => {
+                            let mut moves = get_queen_moves(self, &friendly_color, &(column, row));
+                            pseudo_legal_moves.append(&mut moves);
+                        }
 
-                Pieces::WRook | Pieces::BRook => {
-                    let mut rook_moves = get_rook_moves(self, &index);
-                    pseudo_legal_moves.append(&mut rook_moves);
-                }
+                        Rook => {
+                            let mut moves = get_rook_moves(self, &friendly_color, &(column, row));
+                            pseudo_legal_moves.append(&mut moves);
+                        }
 
-                Pieces::WBishop | Pieces::BBishop => {
-                    let mut bishop_moves = get_bishop_moves(self, &index);
-                    pseudo_legal_moves.append(&mut bishop_moves);
-                }
+                        Bishop => {
+                            let mut moves = get_bishop_moves(self, &friendly_color, &(column, row));
+                            pseudo_legal_moves.append(&mut moves);
+                        }
 
-                Pieces::WKnight | Pieces::BKnight => {
-                    let mut knight_moves = get_knight_moves(self, &index);
-                    pseudo_legal_moves.append(&mut knight_moves);
-                }
+                        Knight => {
+                            let mut moves = get_knight_moves(self, &friendly_color, &(column, row));
+                            pseudo_legal_moves.append(&mut moves);
+                        }
 
-                Pieces::WPawn | Pieces::BPawn => {
-                    let mut pawn_moves = get_pawn_moves(self, &index);
-                    pseudo_legal_moves.append(&mut pawn_moves);
+                        Pawn => {
+                            let mut moves = get_pawn_moves(self, &friendly_color, &(column, row));
+                            pseudo_legal_moves.append(&mut moves);
+                        }
+                    },
                 }
             }
         }
@@ -93,43 +99,56 @@ impl ChessBoard {
     }
 
     pub fn make_move_on_board(board: &mut Board, move_to_make: &Move) {
+        let start_pos_x = move_to_make.start_pos.0;
+        let start_pos_y = move_to_make.start_pos.1;
+
+        let end_pos_x = move_to_make.end_pos.0;
+        let end_pos_y = move_to_make.end_pos.1;
+
         match move_to_make.meta_data {
             MetaData::Move | MetaData::PawnMove | MetaData::Capture | MetaData::PawnDoubleMove => {
-                board[move_to_make.end_pos] = board[move_to_make.start_pos];
-                board[move_to_make.start_pos] = EMPTY_SQUARE;
+                board[end_pos_y][end_pos_x] = board[start_pos_y][start_pos_x];
+                board[start_pos_y][start_pos_x] = None;
             }
 
-            MetaData::Promotion(piece_type) => {
-                board[move_to_make.end_pos] = BoardSquare { piece_type };
-                board[move_to_make.start_pos] = EMPTY_SQUARE;
+            MetaData::Promotion(piece) => {
+                board[end_pos_y][end_pos_x] = Some(piece);
+                board[start_pos_y][start_pos_x] = None;
             }
 
             MetaData::EnPassant => {
-                let delta_position: i8 = if move_to_make.start_pos < move_to_make.end_pos {
-                    8
+                let target_square: Position = if move_to_make.start_pos.1 < move_to_make.end_pos.1 {
+                    (end_pos_x, end_pos_y + 1)
                 } else {
-                    -8
+                    (end_pos_x, end_pos_y - 1)
                 };
 
-                board[move_to_make.end_pos] = board[move_to_make.start_pos];
+                board[end_pos_y][end_pos_x] = board[start_pos_y][start_pos_x];
 
-                board[move_to_make.start_pos] = EMPTY_SQUARE;
-                board[(move_to_make.end_pos as i8 + delta_position) as usize] = EMPTY_SQUARE;
+                board[start_pos_y][start_pos_x] = None;
+                board[target_square.1][target_square.0] = None;
             }
 
             MetaData::Castling => {
-                let (rook_start_position, rook_end_position): (usize, usize) =
-                    if move_to_make.start_pos < move_to_make.end_pos {
-                        (move_to_make.start_pos + 3, move_to_make.start_pos + 1)
+                let (rook_start_position, rook_end_position): (Position, Position) =
+                    if move_to_make.start_pos.0 < move_to_make.end_pos.0 {
+                        (
+                            (move_to_make.start_pos.0 + 3, move_to_make.start_pos.1),
+                            (move_to_make.start_pos.0 + 1, move_to_make.start_pos.1),
+                        )
                     } else {
-                        (move_to_make.start_pos - 4, move_to_make.start_pos - 1)
+                        (
+                            (move_to_make.start_pos.0 - 4, move_to_make.start_pos.1),
+                            (move_to_make.start_pos.0 - 1, move_to_make.start_pos.1),
+                        )
                     };
 
-                board[move_to_make.end_pos] = board[move_to_make.start_pos];
-                board[rook_end_position] = board[rook_start_position];
+                board[end_pos_y][end_pos_x] = board[start_pos_y][start_pos_x];
+                board[rook_end_position.1][rook_end_position.0] =
+                    board[rook_start_position.1][rook_start_position.0];
 
-                board[move_to_make.start_pos] = EMPTY_SQUARE;
-                board[rook_start_position] = EMPTY_SQUARE;
+                board[start_pos_y][start_pos_x] = None;
+                board[rook_start_position.1][rook_start_position.0] = None;
             }
         }
     }

--- a/src/chess/chess_moves/legal_moves.rs
+++ b/src/chess/chess_moves/legal_moves.rs
@@ -15,19 +15,13 @@ use crate::chess::chess_moves::legal_moves::knight_piece::get_knight_moves;
 use crate::chess::chess_moves::legal_moves::pawn_piece::get_pawn_moves;
 use crate::chess::chess_moves::legal_moves::queen_piece::get_queen_moves;
 use crate::chess::chess_moves::legal_moves::rook_piece::get_rook_moves;
-use crate::chess::{BoardSquare, ChessBoard, MetaData, Move, Pieces, ARR_SIZE, EMPTY_PIECE};
+use crate::chess::{Board, BoardSquare, ChessBoard, MetaData, Move, Pieces, ARR_SIZE, EMPTY_PIECE};
 
 impl ChessBoard {
     pub fn legal_moves(&self) -> Vec<Move> {
         let mut legal_moves: Vec<Move> = Vec::new();
 
         let pseudo_legal_moves: Vec<Move> = self.pseudo_legal_moves();
-
-        let (current_color, king_piece): (Color, Pieces) = if self.white_is_side_to_move {
-            (Color::White, Pieces::WKing)
-        } else {
-            (Color::Black, Pieces::BKing)
-        };
 
         let king_position = find_first_matching_chess_piece(&self.board, king_piece)
             .expect("Both kings most exist on all boards!");
@@ -96,7 +90,7 @@ impl ChessBoard {
         pseudo_legal_moves
     }
 
-    pub fn make_move_on_board(board: &mut [BoardSquare; ARR_SIZE], move_to_make: &Move) {
+    pub fn make_move_on_board(board: &mut Board, move_to_make: &Move) {
         match move_to_make.meta_data {
             MetaData::Move | MetaData::PawnMove | MetaData::Capture | MetaData::PawnDoubleMove => {
                 board[move_to_make.end_pos] = board[move_to_make.start_pos];

--- a/src/chess/chess_moves/legal_moves.rs
+++ b/src/chess/chess_moves/legal_moves.rs
@@ -15,7 +15,7 @@ use crate::chess::chess_moves::legal_moves::knight_piece::get_knight_moves;
 use crate::chess::chess_moves::legal_moves::pawn_piece::get_pawn_moves;
 use crate::chess::chess_moves::legal_moves::queen_piece::get_queen_moves;
 use crate::chess::chess_moves::legal_moves::rook_piece::get_rook_moves;
-use crate::chess::{BoardPiece, ChessBoard, MetaData, Move, Pieces, ARR_SIZE, EMPTY_PIECE};
+use crate::chess::{BoardSquare, ChessBoard, MetaData, Move, Pieces, ARR_SIZE, EMPTY_PIECE};
 
 impl ChessBoard {
     pub fn legal_moves(&self) -> Vec<Move> {
@@ -96,7 +96,7 @@ impl ChessBoard {
         pseudo_legal_moves
     }
 
-    pub fn make_move_on_board(board: &mut [BoardPiece; ARR_SIZE], move_to_make: &Move) {
+    pub fn make_move_on_board(board: &mut [BoardSquare; ARR_SIZE], move_to_make: &Move) {
         match move_to_make.meta_data {
             MetaData::Move | MetaData::PawnMove | MetaData::Capture | MetaData::PawnDoubleMove => {
                 board[move_to_make.end_pos] = board[move_to_make.start_pos];
@@ -104,7 +104,7 @@ impl ChessBoard {
             }
 
             MetaData::Promotion(piece_type) => {
-                board[move_to_make.end_pos] = BoardPiece { piece_type };
+                board[move_to_make.end_pos] = BoardSquare { piece_type };
                 board[move_to_make.start_pos] = EMPTY_PIECE;
             }
 

--- a/src/chess/chess_moves/legal_moves/bishop_piece.rs
+++ b/src/chess/chess_moves/legal_moves/bishop_piece.rs
@@ -1,11 +1,11 @@
 use crate::chess::chess_moves::legal_moves::generic_piece::get_multi_step_moves;
 use crate::chess::chess_moves::piece_logic::BISHOP_DIRECTION;
-use crate::chess::{ChessBoard, Color, Coordinate, Move};
+use crate::chess::{ChessBoard, Color, Move, Position};
 
 pub fn get_bishop_moves(
     chess_board: &ChessBoard,
     friendly_color: &Color,
-    piece_position: &Coordinate,
+    piece_position: &Position,
 ) -> Vec<Move> {
     get_multi_step_moves(
         chess_board,

--- a/src/chess/chess_moves/legal_moves/bishop_piece.rs
+++ b/src/chess/chess_moves/legal_moves/bishop_piece.rs
@@ -1,7 +1,16 @@
 use crate::chess::chess_moves::legal_moves::generic_piece::get_multi_step_moves;
 use crate::chess::chess_moves::piece_logic::BISHOP_DIRECTION;
-use crate::chess::{ChessBoard, Move};
+use crate::chess::{ChessBoard, Color, Coordinate, Move};
 
-pub fn get_bishop_moves(chess_board: &ChessBoard, piece_position: &usize) -> Vec<Move> {
-    get_multi_step_moves(chess_board, piece_position, BISHOP_DIRECTION.as_slice())
+pub fn get_bishop_moves(
+    chess_board: &ChessBoard,
+    friendly_color: &Color,
+    piece_position: &Coordinate,
+) -> Vec<Move> {
+    get_multi_step_moves(
+        chess_board,
+        piece_position,
+        friendly_color,
+        BISHOP_DIRECTION.as_slice(),
+    )
 }

--- a/src/chess/chess_moves/legal_moves/generic_piece.rs
+++ b/src/chess/chess_moves/legal_moves/generic_piece.rs
@@ -1,20 +1,11 @@
 use crate::chess::chess_moves::piece_logic::{BLACK_PIECES, WHITE_PIECES};
 use crate::chess::chess_moves::MoveDirection;
-use crate::chess::Pieces::{
-    BBishop, BKing, BKnight, BPawn, BQueen, BRook, WBishop, WKing, WKnight, WPawn, WQueen, WRook,
-};
-use crate::chess::{BoardSquare, ChessBoard, MetaData, Move, Pieces, ARR_SIZE};
-
-#[derive(PartialEq)]
-pub enum Color {
-    White,
-    Black,
-    Empty,
-}
+use crate::chess::Pieces::{Bishop, King, Knight, Pawn, Queen, Rook};
+use crate::chess::{Board, BoardSquare, ChessBoard, MetaData, Move};
 
 pub fn get_single_step_moves(
     chess_board: &ChessBoard,
-    piece_position: &usize,
+    piece_position: &(usize, usize),
     directions: &[MoveDirection],
 ) -> Vec<Move> {
     let mut moves: Vec<Move> = Vec::new();
@@ -135,24 +126,13 @@ pub fn check_multi_step_for_piece_exists(
     false
 }
 
-pub fn find_first_matching_chess_piece(
-    board: &[BoardSquare; ARR_SIZE],
-    piece_to_find: Pieces,
-) -> Option<usize> {
+pub fn find_first_matching_chess_piece(board: &Board, piece_to_find: Pieces) -> Option<usize> {
     for (pos, square) in board.iter().enumerate() {
         if square.piece_type == piece_to_find {
             return Some(pos);
         }
     }
     None
-}
-
-pub fn get_friendly_and_enemy_pieces(white_is_side_to_move: bool) -> ([Pieces; 6], [Pieces; 6]) {
-    if white_is_side_to_move {
-        (WHITE_PIECES, BLACK_PIECES)
-    } else {
-        (BLACK_PIECES, WHITE_PIECES)
-    }
 }
 
 fn get_color_from_piece(piece: Pieces) -> Color {

--- a/src/chess/chess_moves/legal_moves/generic_piece.rs
+++ b/src/chess/chess_moves/legal_moves/generic_piece.rs
@@ -1,23 +1,19 @@
-use crate::chess::chess_moves::piece_logic::{BLACK_PIECES, WHITE_PIECES};
 use crate::chess::chess_moves::MoveDirection;
-use crate::chess::Pieces::{Bishop, King, Knight, Pawn, Queen, Rook};
-use crate::chess::{Board, BoardSquare, ChessBoard, MetaData, Move};
+use crate::chess::{Board, ChessBoard, Color, Coordinate, MetaData, Move, Piece};
 
 pub fn get_single_step_moves(
     chess_board: &ChessBoard,
-    piece_position: &(usize, usize),
+    piece_position: &Coordinate,
+    piece_color: &Color,
     directions: &[MoveDirection],
 ) -> Vec<Move> {
     let mut moves: Vec<Move> = Vec::new();
 
-    let (friendly_pieces, _) = get_friendly_and_enemy_pieces(chess_board.white_is_side_to_move);
-
     for direction in directions {
-        if direction.piece_can_travel(&chess_board.board, &friendly_pieces, piece_position) {
-            let new_position: usize = direction.walk_from_position(*piece_position);
+        if direction.piece_can_travel(&chess_board.board, piece_color, piece_position) {
+            let new_position: Coordinate = direction.walk_from_position(*piece_position);
 
-            let meta_data: MetaData = if chess_board.board[new_position].piece_type == Pieces::Empty
-            {
+            let meta_data: MetaData = if chess_board.board[new_position.1][new_position.0] == None {
                 MetaData::Move
             } else {
                 MetaData::Capture
@@ -38,21 +34,20 @@ pub fn get_single_step_moves(
 
 pub fn get_multi_step_moves(
     chess_board: &ChessBoard,
-    piece_position: &usize,
+    piece_position: &Coordinate,
+    piece_color: &Color,
     directions: &[MoveDirection],
 ) -> Vec<Move> {
     let mut moves: Vec<Move> = Vec::new();
 
-    let (friendly_pieces, _) = get_friendly_and_enemy_pieces(chess_board.white_is_side_to_move);
-
     for direction in directions {
-        let mut current_position: usize = *piece_position;
+        let mut current_position: Coordinate = *piece_position;
 
-        while direction.piece_can_travel(&chess_board.board, &friendly_pieces, &current_position) {
+        while direction.piece_can_travel(&chess_board.board, piece_color, &current_position) {
             current_position = direction.walk_from_position(current_position);
 
             let meta_data: MetaData =
-                if chess_board.board[current_position].piece_type == Pieces::Empty {
+                if chess_board.board[current_position.1][current_position.0] == None {
                     MetaData::Move
                 } else {
                     MetaData::Capture
@@ -71,20 +66,14 @@ pub fn get_multi_step_moves(
 }
 
 pub fn check_single_step_for_piece_exists(
-    piece_to_check_for: &Pieces,
-    board: &[BoardSquare; ARR_SIZE],
+    piece_to_check_for: &Piece,
+    board: &Board,
     directions: &[MoveDirection],
-    starting_position: &usize,
+    friendly_color: &Color,
+    starting_position: &Coordinate,
 ) -> bool {
-    let enemy_pieces: [Pieces; 6];
-
-    match get_enemy_pieces_from_color(get_color_from_piece(*piece_to_check_for)) {
-        Some(enemies) => enemy_pieces = enemies,
-        None => return false,
-    }
-
     for direction in directions {
-        if direction.piece_can_travel(board, &enemy_pieces, starting_position) {
+        if direction.piece_can_travel(board, friendly_color, starting_position) {
             let new_position = direction.walk_from_position(*starting_position);
 
             if board[new_position].piece_type == *piece_to_check_for {
@@ -96,61 +85,41 @@ pub fn check_single_step_for_piece_exists(
 }
 
 pub fn check_multi_step_for_piece_exists(
-    piece_to_check_for: &Pieces,
-    board: &[BoardSquare; ARR_SIZE],
+    piece_to_check_for: &Piece,
+    board: &Board,
     directions: &[MoveDirection],
-    starting_position: &usize,
+    friendly_color: &Color,
+    starting_position: &Coordinate,
 ) -> bool {
-    let enemy_pieces: [Pieces; 6];
-
-    match get_enemy_pieces_from_color(get_color_from_piece(*piece_to_check_for)) {
-        Some(enemies) => enemy_pieces = enemies,
-        None => return false,
-    }
-
     for direction in directions {
         let mut current_position = *starting_position;
-        while direction.piece_can_travel(board, &enemy_pieces, &current_position) {
+        while direction.piece_can_travel(board, friendly_color, &current_position) {
             current_position = direction.walk_from_position(current_position);
 
-            if board[current_position].piece_type == *piece_to_check_for {
-                return true;
-            }
-            if board[current_position].piece_type == Pieces::Empty {
-                continue;
-            } else {
-                break;
+            match board[current_position.1][current_position.0] {
+                Some(piece) => {
+                    if piece == *piece_to_check_for {
+                        return true;
+                    } else {
+                        break;
+                    }
+                }
+                None => continue,
             }
         }
     }
     false
 }
 
-pub fn find_first_matching_chess_piece(board: &Board, piece_to_find: Pieces) -> Option<usize> {
-    for (pos, square) in board.iter().enumerate() {
-        if square.piece_type == piece_to_find {
-            return Some(pos);
+pub fn find_first_matching_chess_piece(board: &Board, piece_to_find: &Piece) -> Option<Coordinate> {
+    for (i, file) in board.iter().enumerate() {
+        for (j, square) in file.iter().enumerate() {
+            if let Some(piece) = square {
+                if *piece == *piece_to_find {
+                    return Some((i, j));
+                }
+            }
         }
     }
     None
-}
-
-fn get_color_from_piece(piece: Pieces) -> Color {
-    match piece {
-        WKing | WKnight | WRook | WQueen | WBishop | WPawn => Color::White,
-
-        BKing | BKnight | BRook | BQueen | BBishop | BPawn => Color::Black,
-
-        Pieces::Empty => Color::Empty,
-    }
-}
-
-pub fn get_enemy_pieces_from_color(color: Color) -> Option<[Pieces; 6]> {
-    match color {
-        Color::Black => Some([WKing, WQueen, WRook, WBishop, WKnight, WPawn]),
-
-        Color::White => Some([BKing, BQueen, BRook, BBishop, BKnight, BPawn]),
-
-        Color::Empty => None,
-    }
 }

--- a/src/chess/chess_moves/legal_moves/generic_piece.rs
+++ b/src/chess/chess_moves/legal_moves/generic_piece.rs
@@ -1,9 +1,9 @@
 use crate::chess::chess_moves::MoveDirection;
-use crate::chess::{Board, ChessBoard, Color, Coordinate, MetaData, Move, Piece};
+use crate::chess::{Board, ChessBoard, Color, MetaData, Move, Piece, Position};
 
 pub fn get_single_step_moves(
     chess_board: &ChessBoard,
-    piece_position: &Coordinate,
+    piece_position: &Position,
     piece_color: &Color,
     directions: &[MoveDirection],
 ) -> Vec<Move> {
@@ -11,7 +11,7 @@ pub fn get_single_step_moves(
 
     for direction in directions {
         if direction.piece_can_travel(&chess_board.board, piece_color, piece_position) {
-            let new_position: Coordinate = direction.walk_from_position(*piece_position);
+            let new_position: Position = direction.walk_from_position(*piece_position);
 
             let meta_data: MetaData = if chess_board.board[new_position.1][new_position.0] == None {
                 MetaData::Move
@@ -34,14 +34,14 @@ pub fn get_single_step_moves(
 
 pub fn get_multi_step_moves(
     chess_board: &ChessBoard,
-    piece_position: &Coordinate,
+    piece_position: &Position,
     piece_color: &Color,
     directions: &[MoveDirection],
 ) -> Vec<Move> {
     let mut moves: Vec<Move> = Vec::new();
 
     for direction in directions {
-        let mut current_position: Coordinate = *piece_position;
+        let mut current_position: Position = *piece_position;
 
         while direction.piece_can_travel(&chess_board.board, piece_color, &current_position) {
             current_position = direction.walk_from_position(current_position);
@@ -66,18 +66,22 @@ pub fn get_multi_step_moves(
 }
 
 pub fn check_single_step_for_piece_exists(
-    piece_to_check_for: &Piece,
+    piece_to_check_for: Piece,
     board: &Board,
     directions: &[MoveDirection],
     friendly_color: &Color,
-    starting_position: &Coordinate,
+    starting_position: &Position,
 ) -> bool {
     for direction in directions {
         if direction.piece_can_travel(board, friendly_color, starting_position) {
             let new_position = direction.walk_from_position(*starting_position);
 
-            if board[new_position].piece_type == *piece_to_check_for {
-                return true;
+            if let Some(piece) = board[new_position.1][new_position.0] {
+                return if piece == piece_to_check_for {
+                    true
+                } else {
+                    false
+                };
             }
         }
     }
@@ -85,11 +89,11 @@ pub fn check_single_step_for_piece_exists(
 }
 
 pub fn check_multi_step_for_piece_exists(
-    piece_to_check_for: &Piece,
+    piece_to_check_for: Piece,
     board: &Board,
     directions: &[MoveDirection],
     friendly_color: &Color,
-    starting_position: &Coordinate,
+    starting_position: &Position,
 ) -> bool {
     for direction in directions {
         let mut current_position = *starting_position;
@@ -98,7 +102,7 @@ pub fn check_multi_step_for_piece_exists(
 
             match board[current_position.1][current_position.0] {
                 Some(piece) => {
-                    if piece == *piece_to_check_for {
+                    if piece == piece_to_check_for {
                         return true;
                     } else {
                         break;
@@ -111,12 +115,12 @@ pub fn check_multi_step_for_piece_exists(
     false
 }
 
-pub fn find_first_matching_chess_piece(board: &Board, piece_to_find: &Piece) -> Option<Coordinate> {
+pub fn find_first_matching_chess_piece(board: &Board, piece_to_find: &Piece) -> Option<Position> {
     for (i, file) in board.iter().enumerate() {
         for (j, square) in file.iter().enumerate() {
             if let Some(piece) = square {
                 if *piece == *piece_to_find {
-                    return Some((i, j));
+                    return Some((j, i));
                 }
             }
         }

--- a/src/chess/chess_moves/legal_moves/generic_piece.rs
+++ b/src/chess/chess_moves/legal_moves/generic_piece.rs
@@ -3,7 +3,7 @@ use crate::chess::chess_moves::MoveDirection;
 use crate::chess::Pieces::{
     BBishop, BKing, BKnight, BPawn, BQueen, BRook, WBishop, WKing, WKnight, WPawn, WQueen, WRook,
 };
-use crate::chess::{BoardPiece, ChessBoard, MetaData, Move, Pieces, ARR_SIZE};
+use crate::chess::{BoardSquare, ChessBoard, MetaData, Move, Pieces, ARR_SIZE};
 
 #[derive(PartialEq)]
 pub enum Color {
@@ -81,7 +81,7 @@ pub fn get_multi_step_moves(
 
 pub fn check_single_step_for_piece_exists(
     piece_to_check_for: &Pieces,
-    board: &[BoardPiece; ARR_SIZE],
+    board: &[BoardSquare; ARR_SIZE],
     directions: &[MoveDirection],
     starting_position: &usize,
 ) -> bool {
@@ -106,7 +106,7 @@ pub fn check_single_step_for_piece_exists(
 
 pub fn check_multi_step_for_piece_exists(
     piece_to_check_for: &Pieces,
-    board: &[BoardPiece; ARR_SIZE],
+    board: &[BoardSquare; ARR_SIZE],
     directions: &[MoveDirection],
     starting_position: &usize,
 ) -> bool {
@@ -136,7 +136,7 @@ pub fn check_multi_step_for_piece_exists(
 }
 
 pub fn find_first_matching_chess_piece(
-    board: &[BoardPiece; ARR_SIZE],
+    board: &[BoardSquare; ARR_SIZE],
     piece_to_find: Pieces,
 ) -> Option<usize> {
     for (pos, square) in board.iter().enumerate() {

--- a/src/chess/chess_moves/legal_moves/king_piece.rs
+++ b/src/chess/chess_moves/legal_moves/king_piece.rs
@@ -1,6 +1,5 @@
 use crate::chess::chess_moves::legal_moves::generic_piece::{
     check_multi_step_for_piece_exists, check_single_step_for_piece_exists, get_single_step_moves,
-    Color,
 };
 
 use crate::chess::chess_moves::piece_logic::{
@@ -8,15 +7,18 @@ use crate::chess::chess_moves::piece_logic::{
     ROOK_DIRECTION, WHITE_PAWN_ATTACK_DIRECTION,
 };
 use crate::chess::chess_moves::MoveDirection;
-use crate::chess::Pieces::{
-    BBishop, BKing, BKnight, BPawn, BQueen, BRook, WBishop, WKing, WKnight, WPawn, WQueen, WRook,
-};
-use crate::chess::{BoardSquare, ChessBoard, MetaData, Move, ARR_SIZE, EMPTY_PIECE};
+use crate::chess::PieceType::{Bishop, King, Knight, Pawn, Queen};
+use crate::chess::{ChessBoard, Color, Coordinate, MetaData, Move};
 
-pub fn get_king_moves(chess_board: &ChessBoard, piece_position: &usize) -> Vec<Move> {
+pub fn get_king_moves(
+    chess_board: &ChessBoard,
+    friendly_color: &Color,
+    piece_position: &Coordinate,
+) -> Vec<Move> {
     let mut king_moves: Vec<Move> = get_single_step_moves(
         chess_board,
         piece_position,
+        friendly_color,
         KING_AND_QUEEN_DIRECTION.as_slice(),
     );
     let king_color: Color;
@@ -179,7 +181,7 @@ fn check_king_through_rook_positions_not_in_check(
 /** Returns true if all given positions are empty */
 fn check_board_for_empty_pieces(positions: &[usize], board: &[BoardSquare; ARR_SIZE]) -> bool {
     for position in positions {
-        if board[*position] != EMPTY_PIECE {
+        if board[*position] != EMPTY_SQUARE {
             return false;
         }
     }

--- a/src/chess/chess_moves/legal_moves/king_piece.rs
+++ b/src/chess/chess_moves/legal_moves/king_piece.rs
@@ -11,7 +11,7 @@ use crate::chess::chess_moves::MoveDirection;
 use crate::chess::Pieces::{
     BBishop, BKing, BKnight, BPawn, BQueen, BRook, WBishop, WKing, WKnight, WPawn, WQueen, WRook,
 };
-use crate::chess::{BoardPiece, ChessBoard, MetaData, Move, ARR_SIZE, EMPTY_PIECE};
+use crate::chess::{BoardSquare, ChessBoard, MetaData, Move, ARR_SIZE, EMPTY_PIECE};
 
 pub fn get_king_moves(chess_board: &ChessBoard, piece_position: &usize) -> Vec<Move> {
     let mut king_moves: Vec<Move> = get_single_step_moves(
@@ -79,7 +79,7 @@ pub fn get_king_moves(chess_board: &ChessBoard, piece_position: &usize) -> Vec<M
 
 /** This function assumes that a king is unique, i.e. there only exists one king of each color. */
 pub fn king_is_checked(
-    board: &[BoardPiece; ARR_SIZE],
+    board: &[BoardSquare; ARR_SIZE],
     king_position: &usize,
     king_color: &Color,
 ) -> bool {
@@ -164,7 +164,7 @@ pub fn king_is_checked(
 
 fn check_king_through_rook_positions_not_in_check(
     positions: &[usize],
-    board: &[BoardPiece; ARR_SIZE],
+    board: &[BoardSquare; ARR_SIZE],
     king_color: &Color,
 ) -> bool {
     for position in positions {
@@ -177,7 +177,7 @@ fn check_king_through_rook_positions_not_in_check(
 }
 
 /** Returns true if all given positions are empty */
-fn check_board_for_empty_pieces(positions: &[usize], board: &[BoardPiece; ARR_SIZE]) -> bool {
+fn check_board_for_empty_pieces(positions: &[usize], board: &[BoardSquare; ARR_SIZE]) -> bool {
     for position in positions {
         if board[*position] != EMPTY_PIECE {
             return false;

--- a/src/chess/chess_moves/legal_moves/knight_piece.rs
+++ b/src/chess/chess_moves/legal_moves/knight_piece.rs
@@ -1,7 +1,16 @@
 use crate::chess::chess_moves::legal_moves::generic_piece::get_single_step_moves;
 use crate::chess::chess_moves::piece_logic::KNIGHT_DIRECTION;
-use crate::chess::{ChessBoard, Move};
+use crate::chess::{ChessBoard, Color, Move, Position};
 
-pub fn get_knight_moves(chess_board: &ChessBoard, piece_position: &usize) -> Vec<Move> {
-    get_single_step_moves(chess_board, piece_position, KNIGHT_DIRECTION.as_slice())
+pub fn get_knight_moves(
+    chess_board: &ChessBoard,
+    friendly_color: &Color,
+    piece_position: &Position,
+) -> Vec<Move> {
+    get_single_step_moves(
+        chess_board,
+        piece_position,
+        friendly_color,
+        KNIGHT_DIRECTION.as_slice(),
+    )
 }

--- a/src/chess/chess_moves/legal_moves/pawn_piece.rs
+++ b/src/chess/chess_moves/legal_moves/pawn_piece.rs
@@ -6,7 +6,7 @@ use crate::chess::chess_moves::piece_logic::{
     WHITE_PAWN_DIRECTION,
 };
 use crate::chess::chess_moves::MoveDirection;
-use crate::chess::{BoardPiece, ChessBoard, MetaData, Move, Pieces, SquarePosition, ARR_SIZE};
+use crate::chess::{BoardSquare, ChessBoard, MetaData, Move, Pieces, SquarePosition, ARR_SIZE};
 
 pub fn get_pawn_moves(chess_board: &ChessBoard, piece_position: &usize) -> Vec<Move> {
     let (friendly_pieces, enemy_pieces) =
@@ -125,7 +125,7 @@ fn check_en_passant_move(
 fn get_pawn_double_move(
     white_is_side_to_move: bool,
     piece_position: &usize,
-    board: &[BoardPiece; ARR_SIZE],
+    board: &[BoardSquare; ARR_SIZE],
     friendly_pieces: &[Pieces; 6],
     square_position: &SquarePosition,
     direction: &MoveDirection,
@@ -154,7 +154,7 @@ fn get_pawn_double_move(
 fn get_promotion_moves(
     white_is_side_to_move: bool,
     piece_position: &usize,
-    board: &[BoardPiece; ARR_SIZE],
+    board: &[BoardSquare; ARR_SIZE],
     friendly_pieces: &[Pieces; 6],
     square_position: &SquarePosition,
 ) -> Vec<Move> {

--- a/src/chess/chess_moves/legal_moves/pawn_piece.rs
+++ b/src/chess/chess_moves/legal_moves/pawn_piece.rs
@@ -63,7 +63,7 @@ pub fn get_pawn_moves(
     let mut promotion_moves =
         get_promotion_moves(friendly_color, piece_position, &chess_board.board);
 
-    if pawn_moves.len() > 0 {
+    if promotion_moves.len() > 0 {
         pawn_moves.append(&mut promotion_moves);
     }
 
@@ -143,21 +143,21 @@ fn get_pawn_double_move(
     direction: &MoveDirection,
 ) -> Option<Move> {
     let (pawn_starting_rank, direction_change): (usize, i8) = if *current_piece_color == White {
-        (2, 1)
+        (1, 1)
     } else {
-        (7, -1)
+        (6, -1)
     };
 
     let mut double_move_direction = *direction;
     double_move_direction.dy += direction_change;
 
-    if pawn_starting_rank == piece_position.0
+    if pawn_starting_rank == piece_position.1
         && double_move_direction.piece_can_travel(board, current_piece_color, piece_position)
     {
         let double_move: Move = Move {
             start_pos: *piece_position,
             end_pos: double_move_direction.walk_from_position(*piece_position),
-            meta_data: MetaData::PawnMove,
+            meta_data: MetaData::PawnDoubleMove,
         };
         return Some(double_move);
     }
@@ -169,7 +169,7 @@ fn get_promotion_moves(piece_color: &Color, piece_position: &Position, board: &B
     let (direction, _): (MoveDirection, [MoveDirection; 2]) =
         get_pawn_direction_and_attack(piece_color);
 
-    let promotion_rank: usize = if *piece_color == White { 7 } else { 2 };
+    let promotion_rank: usize = if *piece_color == White { 6 } else { 1 };
 
     let promotion_pieces = if *piece_color == White {
         [

--- a/src/chess/chess_moves/legal_moves/queen_piece.rs
+++ b/src/chess/chess_moves/legal_moves/queen_piece.rs
@@ -1,11 +1,16 @@
 use crate::chess::chess_moves::legal_moves::generic_piece::get_multi_step_moves;
 use crate::chess::chess_moves::piece_logic::KING_AND_QUEEN_DIRECTION;
-use crate::chess::{ChessBoard, Move};
+use crate::chess::{ChessBoard, Color, Move, Position};
 
-pub fn get_queen_moves(chess_board: &ChessBoard, piece_position: &usize) -> Vec<Move> {
+pub fn get_queen_moves(
+    chess_board: &ChessBoard,
+    friendly_color: &Color,
+    piece_position: &Position,
+) -> Vec<Move> {
     get_multi_step_moves(
         chess_board,
         piece_position,
+        friendly_color,
         KING_AND_QUEEN_DIRECTION.as_slice(),
     )
 }

--- a/src/chess/chess_moves/legal_moves/rook_piece.rs
+++ b/src/chess/chess_moves/legal_moves/rook_piece.rs
@@ -1,11 +1,11 @@
 use crate::chess::chess_moves::legal_moves::generic_piece::get_multi_step_moves;
 use crate::chess::chess_moves::piece_logic::ROOK_DIRECTION;
-use crate::chess::{ChessBoard, Color, Coordinate, Move};
+use crate::chess::{ChessBoard, Color, Move, Position};
 
 pub fn get_rook_moves(
     chess_board: &ChessBoard,
     friendly_color: &Color,
-    piece_position: &Coordinate,
+    piece_position: &Position,
 ) -> Vec<Move> {
     get_multi_step_moves(
         chess_board,

--- a/src/chess/chess_moves/legal_moves/rook_piece.rs
+++ b/src/chess/chess_moves/legal_moves/rook_piece.rs
@@ -1,7 +1,16 @@
 use crate::chess::chess_moves::legal_moves::generic_piece::get_multi_step_moves;
 use crate::chess::chess_moves::piece_logic::ROOK_DIRECTION;
-use crate::chess::{ChessBoard, Move};
+use crate::chess::{ChessBoard, Color, Coordinate, Move};
 
-pub fn get_rook_moves(chess_board: &ChessBoard, piece_position: &usize) -> Vec<Move> {
-    get_multi_step_moves(chess_board, piece_position, ROOK_DIRECTION.as_slice())
+pub fn get_rook_moves(
+    chess_board: &ChessBoard,
+    friendly_color: &Color,
+    piece_position: &Coordinate,
+) -> Vec<Move> {
+    get_multi_step_moves(
+        chess_board,
+        piece_position,
+        friendly_color,
+        ROOK_DIRECTION.as_slice(),
+    )
 }

--- a/src/chess/chess_moves/meta_data.rs
+++ b/src/chess/chess_moves/meta_data.rs
@@ -50,7 +50,7 @@ impl ChessBoard {
 
     fn update_fullmove_counter(&mut self) {
         if !self.white_is_side_to_move {
-            self.fullmove_counter += 1;
+            self.full_move_counter += 1;
         }
     }
 
@@ -65,9 +65,9 @@ impl ChessBoard {
     }
 
     fn increment_half_move_clock(&mut self) {
-        self.halfmove_clock += 1;
+        self.half_move_clock += 1;
     }
     fn reset_half_move_clock(&mut self) {
-        self.halfmove_clock = 0;
+        self.half_move_clock = 0;
     }
 }

--- a/src/chess/chess_moves/meta_data.rs
+++ b/src/chess/chess_moves/meta_data.rs
@@ -23,10 +23,12 @@ impl ChessBoard {
             }
 
             MetaData::PawnDoubleMove => {
-                if move_to_make.start_pos < move_to_make.end_pos {
-                    self.en_passant_target_square = Some(move_to_make.start_pos + 8);
-                } else if move_to_make.start_pos > move_to_make.end_pos {
-                    self.en_passant_target_square = Some(move_to_make.start_pos - 8);
+                if move_to_make.start_pos.1 < move_to_make.end_pos.1 {
+                    self.en_passant_target_square =
+                        Some((move_to_make.start_pos.0, move_to_make.start_pos.1 + 1));
+                } else if move_to_make.start_pos.1 > move_to_make.end_pos.1 {
+                    self.en_passant_target_square =
+                        Some((move_to_make.start_pos.0, move_to_make.start_pos.1 - 1));
                 } else {
                     panic!(
                         "PawnDoubleMoves not generated correctly, start position = end position!"

--- a/src/chess/chess_moves/piece_logic.rs
+++ b/src/chess/chess_moves/piece_logic.rs
@@ -1,8 +1,4 @@
 use crate::chess::chess_moves::MoveDirection;
-use crate::chess::Pieces;
-use crate::chess::Pieces::{
-    BBishop, BKing, BKnight, BPawn, BQueen, BRook, WBishop, WKing, WKnight, WPawn, WQueen, WRook,
-};
 
 pub const WHITE_PAWN_DIRECTION: MoveDirection = MoveDirection { dx: 0, dy: 1 };
 
@@ -53,6 +49,3 @@ pub const KNIGHT_DIRECTION: [MoveDirection; 8] = [
     MoveDirection { dx: -1, dy: 2 },
     MoveDirection { dx: -1, dy: -2 },
 ];
-
-pub(crate) const WHITE_PIECES: [Pieces; 6] = [WPawn, WRook, WBishop, WKnight, WQueen, WKing];
-pub(crate) const BLACK_PIECES: [Pieces; 6] = [BPawn, BRook, BBishop, BKnight, BQueen, BKing];

--- a/src/chess/fen.rs
+++ b/src/chess/fen.rs
@@ -1,6 +1,6 @@
 use crate::chess::Color::{Black, White};
 use crate::chess::PieceType::{Bishop, King, Knight, Pawn, Queen, Rook};
-use crate::chess::{Board, Coordinate, Piece, Square, COL_SIZE};
+use crate::chess::{Board, Piece, Position, Square, COL_SIZE};
 
 const ARR_SIZE: usize = 64;
 const ROW_SIZE: usize = 8;
@@ -414,14 +414,14 @@ pub fn parse_fen_castling_ability(fen: &str) -> [bool; 4] {
     return c_ability;
 }
 
-pub fn parse_fen_epawn(fen: &str) -> Option<Coordinate> {
+pub fn parse_fen_epawn(fen: &str) -> Option<Position> {
     let mut fen_iter = fen.chars();
 
     if fen == "-" {
         return None;
     }
 
-    let parsed_epawn: Coordinate;
+    let parsed_epawn: Position;
 
     let epawn_file: usize;
     let epawn_rank: usize;

--- a/src/chess/fen.rs
+++ b/src/chess/fen.rs
@@ -1,8 +1,6 @@
+use crate::chess::Color::{Black, White};
 use crate::chess::PieceType::{Bishop, King, Knight, Pawn, Queen, Rook};
-use crate::chess::{Board, BoardSquare, Coordinate, Piece, PieceType, Square, COL_SIZE};
-use iced::futures::future::err;
-
-use super::ChessBoard;
+use crate::chess::{Board, Coordinate, Piece, Square, COL_SIZE};
 
 const ARR_SIZE: usize = 64;
 const ROW_SIZE: usize = 8;
@@ -282,9 +280,7 @@ pub fn parse_fen_piece_placement(fen_string: &str) -> Board {
     /* Make rank 1 the 0th element instead of the 7th */
     parsed_ranks.reverse();
 
-    let mut board: Board = [[BoardSquare {
-        piece_type: Square::Empty,
-    }; ROW_SIZE]; COL_SIZE];
+    let mut board: Board = [[None; ROW_SIZE]; COL_SIZE];
 
     assert_eq!(
         parsed_ranks.len(),
@@ -306,7 +302,7 @@ pub fn parse_fen_piece_placement(fen_string: &str) -> Board {
 
     for (i, rank) in parsed_ranks.iter().enumerate() {
         for (j, element) in rank.iter().enumerate() {
-            board[i][j].piece_type = *element;
+            board[i][j] = *element;
         }
     }
 
@@ -321,13 +317,13 @@ fn parse_fen_piece_rank(rank_string: &str) -> Vec<Square> {
         match char_to_num {
             Some(mut num) => {
                 while num > 0 {
-                    parsed_rank.push(Square::Empty);
+                    parsed_rank.push(None);
                     num -= 1;
                 }
             }
 
             None => {
-                parsed_rank.push(Square::Piece(parse_fen_piece(c)));
+                parsed_rank.push(Some(parse_fen_piece(c)));
             }
         }
     }
@@ -339,29 +335,29 @@ fn parse_fen_piece_rank(rank_string: &str) -> Vec<Square> {
 }
 
 fn parse_fen_piece(c: char) -> Piece {
-    return match c {
-        'K' => Piece::White(King),
-        'k' => Piece::Black(King),
+    match c {
+        'K' => Piece::new(White, King),
+        'k' => Piece::new(Black, King),
 
-        'Q' => Piece::White(Queen),
-        'q' => Piece::Black(Queen),
+        'Q' => Piece::new(White, Queen),
+        'q' => Piece::new(Black, Queen),
 
-        'R' => Piece::White(Rook),
-        'r' => Piece::Black(Rook),
+        'R' => Piece::new(White, Rook),
+        'r' => Piece::new(Black, Rook),
 
-        'B' => Piece::White(Bishop),
-        'b' => Piece::Black(Bishop),
+        'B' => Piece::new(White, Bishop),
+        'b' => Piece::new(Black, Bishop),
 
-        'N' => Piece::White(Knight),
-        'n' => Piece::Black(Knight),
+        'N' => Piece::new(White, Knight),
+        'n' => Piece::new(Black, Knight),
 
-        'P' => Piece::White(Pawn),
-        'p' => Piece::Black(Pawn),
+        'P' => Piece::new(White, Pawn),
+        'p' => Piece::new(Black, Pawn),
 
         _ => {
             panic!("Not valid FEN: err in parse_fen_piece")
         }
-    };
+    }
 }
 
 pub fn parse_fen_side_to_move(fen: &str) -> bool {
@@ -442,7 +438,7 @@ pub fn parse_fen_epawn(fen: &str) -> Option<Coordinate> {
         'g' => epawn_file = 7,
         'h' => epawn_file = 8,
         _ => {
-            panic!("unkown file character: parse_fen_epawn")
+            panic!("unknown file character: parse_fen_e_pawn")
         }
     }
 
@@ -451,7 +447,7 @@ pub fn parse_fen_epawn(fen: &str) -> Option<Coordinate> {
     let rank: usize = match rank_char.to_digit(10) {
         Some(num) => num as usize,
         None => {
-            panic!("could not parse rank number: parse_fen_epawn")
+            panic!("could not parse rank number: parse_fen_e_pawn")
         }
     };
 
@@ -468,14 +464,14 @@ pub fn parse_fen_epawn(fen: &str) -> Option<Coordinate> {
 
 pub fn parse_fen_half_move_clock(fen: &str) -> u64 {
     let error_msg = format!(
-        "Could not parse FEN halfmove clock: Not a valid number!, string failed to parse: {fen}"
+        "Could not parse FEN half move clock: Not a valid number!, string failed to parse: {fen}"
     );
     fen.parse::<u64>().expect(error_msg.as_str())
 }
 
 pub fn parse_fen_full_move_counter(fen: &str) -> u64 {
     let error_msg = format!(
-        "Could not parse FEN fullmove counter: Not a valid number!, string failed to parse: {fen}"
+        "Could not parse FEN full move counter: Not a valid number!, string failed to parse: {fen}"
     );
     fen.parse::<u64>().expect(error_msg.as_str())
 }

--- a/src/chess/fen.rs
+++ b/src/chess/fen.rs
@@ -1,5 +1,5 @@
 use crate::chess::PieceType::{Bishop, King, Knight, Pawn, Queen, Rook};
-use crate::chess::{Board, BoardSquare, Coordinates, Piece, PieceType, Square, COL_SIZE};
+use crate::chess::{Board, BoardSquare, Coordinate, Piece, PieceType, Square, COL_SIZE};
 use iced::futures::future::err;
 
 use super::ChessBoard;
@@ -418,14 +418,14 @@ pub fn parse_fen_castling_ability(fen: &str) -> [bool; 4] {
     return c_ability;
 }
 
-pub fn parse_fen_epawn(fen: &str) -> Option<Coordinates> {
+pub fn parse_fen_epawn(fen: &str) -> Option<Coordinate> {
     let mut fen_iter = fen.chars();
 
     if fen == "-" {
         return None;
     }
 
-    let parsed_epawn: Coordinates;
+    let parsed_epawn: Coordinate;
 
     let epawn_file: usize;
     let epawn_rank: usize;

--- a/src/chess/fen.rs
+++ b/src/chess/fen.rs
@@ -1,4 +1,6 @@
-use crate::chess::{BoardPiece, Pieces};
+use crate::chess::{BoardSquare, Pieces};
+
+use super::ChessBoard;
 
 const ARR_SIZE: usize = 64;
 const ROW_SIZE: usize = 8;
@@ -7,7 +9,7 @@ const VALID_FEN_BOARD: [char; 21] = [
     '8', '/',
 ];
 
-pub const FEN_START_POS: &str = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+pub const FEN_START_POSITION: &str = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
 
 /* FEN validation functions */
 pub fn is_fen_valid(fen: &str) -> bool {
@@ -245,7 +247,7 @@ mod tests {
 
     #[test]
     fn test_valid_fen1() {
-        assert_eq!(is_fen_valid(FEN_START_POS), true);
+        assert_eq!(is_fen_valid(FEN_START_POSITION), true);
     }
 
     #[test]
@@ -267,7 +269,7 @@ mod tests {
 
 /* FEN parsing functions */
 
-pub fn parse_fen_piece_placement(fen_string: &str) -> [BoardPiece; ARR_SIZE] {
+pub fn parse_fen_piece_placement(fen_string: &str) ->  {
     let fen_ranks: Vec<&str> = fen_string.split('/').collect();
 
     let mut parsed_ranks: Vec<Vec<Pieces>> = Vec::new();
@@ -278,7 +280,7 @@ pub fn parse_fen_piece_placement(fen_string: &str) -> [BoardPiece; ARR_SIZE] {
     /* Make rank 1 the 0th element instead of the 7th */
     parsed_ranks.reverse();
 
-    let mut board = [BoardPiece {
+    let mut board = [BoardSquare {
         piece_type: Pieces::Empty,
     }; ARR_SIZE];
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,8 +10,8 @@ fn main() -> iced::Result {
     let mut board = ChessBoard::new();
 
     let chess_move: Move = Move {
-        start_pos: (4, 2),
-        end_pos: (4, 4),
+        start_pos: (4, 1),
+        end_pos: (4, 3),
         meta_data: MetaData::PawnDoubleMove,
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,7 @@
+extern crate core;
+extern crate core;
+extern crate core;
+
 mod chess;
 mod ui;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,3 @@
-extern crate core;
-extern crate core;
-extern crate core;
-
 mod chess;
 mod ui;
 
@@ -14,9 +10,9 @@ fn main() -> iced::Result {
     let mut board = ChessBoard::new();
 
     let chess_move: Move = Move {
-        start_pos: 12,
-        end_pos: 20,
-        meta_data: MetaData::PawnMove,
+        start_pos: (4, 2),
+        end_pos: (4, 4),
+        meta_data: MetaData::PawnDoubleMove,
     };
 
     match board.make_move(chess_move) {


### PR DESCRIPTION
This pull request switches the board representation to a 2d array which simplifies board checks greatly. With this pull request the chess engine now also generates legal moves through perft(1) from the starting position.